### PR TITLE
remove standard Scratch from the menu  + add some feedback info

### DIFF
--- a/Scratch_GUI/install.sh
+++ b/Scratch_GUI/install.sh
@@ -49,6 +49,8 @@ popd > /dev/null
 feedback "Installing Scratch on the desktop"
 sudo cp -f $FINAL_SCRATCH_PATH/Scratch_Start.desktop $PIHOME/Desktop
 sudo cp -f $FINAL_SCRATCH_PATH/Scratch_Start.desktop /usr/share/applications/
+sudo rm -f /usr/share/raspi-ui-overrides/applications/scratch.desktop
+sudo rm -f /usr/share/applications/scratch.desktop
 sudo lxpanelctl restart
 # Make shortcut executable
 sudo chmod +x $PIHOME/Desktop/Scratch_Start.desktop							# Desktop shortcut permissions.

--- a/Troubleshooting_GUI/install.sh
+++ b/Troubleshooting_GUI/install.sh
@@ -25,6 +25,7 @@ then
     sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes 
 fi
 
+feedback "Installing TroubleShooting"
 
 sudo cp -r $RFR_TOOLS_PATH/$TROUBLESHOOTING $DEXTERLIB_PATH
 # Copy shortcut to desktop.
@@ -35,3 +36,5 @@ sudo cp -f $TROUBLESHOOTING_PATH/Troubleshooting_Start.desktop /home/pi/Desktop
 sudo chmod +x /home/pi/Desktop/Troubleshooting_Start.desktop
 
 delete_folder /home/pi/GoBox/Troubleshooting
+
+feedback "Done with TRoubleshooting"


### PR DESCRIPTION
Removing the Scratch menu entry is meant to avoid user confusion.
Also added some feedback in the Troubleshooting install script in an attempt to see what's going on.