### PR TITLE
hotfix - use http instead of https for apt-get source

### DIFF
--- a/scripts/install_tools.sh
+++ b/scripts/install_tools.sh
@@ -123,8 +123,8 @@ update_install_aptget() {
       # add gpg key for nodejs
       curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
       # add nodejs to apt-get source list
-      sudo sh -c "echo 'deb https://deb.nodesource.com/node_9.x $OS_CODENAME main' > /etc/apt/sources.list.d/nodesource.list"
-      sudo sh -c "echo 'deb-src https://deb.nodesource.com/node_9.x $OS_CODENAME main' >> /etc/apt/sources.list.d/nodesource.list"
+      sudo sh -c "echo 'deb http://deb.nodesource.com/node_9.x $OS_CODENAME main' > /etc/apt/sources.list.d/nodesource.list"
+      sudo sh -c "echo 'deb-src http://deb.nodesource.com/node_9.x $OS_CODENAME main' >> /etc/apt/sources.list.d/nodesource.list"
       echo "Added NodeJS repo to source for apt-get for \"$OS_CODENAME\" distribution"
     else
       echo "Couldn't add Nodejs repo to source because it's not available for \"$OS_CODENAME\" distribution"


### PR DESCRIPTION
Without this change, `sudo apt-get update` doesn't work on older distributions, which is a big show-stopper. 
Fortunately enough, it does work on Stretch - and that's probably because apt-get demands higher security.