### PR TITLE
hotfix - removing script_tools installation that isn't needed

### DIFF
--- a/Scratch_GUI/install.sh
+++ b/Scratch_GUI/install.sh
@@ -17,12 +17,13 @@ RFR_TOOLS=$DEXTERLIB_PATH/RFR_Tools
 SCRATCH=Scratch_GUI
 FINAL_SCRATCH_PATH=$DEXTERLIB_PATH/$SCRATCH
 
-curl -kL dexterindustries.com/update_tools | sudo bash
+# script_tools is installed within each robot's install script
+# script_tools isn't installed with RFR_Tools
 source $PIHOME/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 
 if ! quiet_mode
 then
-    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes 
+    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes
 fi
 
 # ensure ~/Dexter/lib/Dexter exists

--- a/Troubleshooting_GUI/install.sh
+++ b/Troubleshooting_GUI/install.sh
@@ -18,11 +18,13 @@ TROUBLESHOOTING_PATH=$DEXTERLIB_PATH/$TROUBLESHOOTING
 
 mkdir -p $TROUBLESHOOTING_PATH
 
+# script_tools is installed within each robot's install script
+# script_tools isn't installed with RFR_Tools
 source $PIHOME/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 
 if ! quiet_mode
 then
-    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes 
+    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes
 fi
 
 feedback "Installing TroubleShooting"


### PR DESCRIPTION
Removed `curl -kL dexterindustries.com/update_tools | sudo bash` which didn't even do something because it needs to be launched without sudo. 

We don't reinstall script_tools within an install script (aka this Scratch installer) which is called by the bigger install script of R4R_Tools because:
1. script_tools is already installed within each robot and all users will install robots and not this repository.
1. It adds up to the time required to install anything.
1. RFR_Tools isn't meant to be the aggregator where all dependencies are called from - that is the job of each robot's install script.
1. This would be the job of the bigger script to do this in RFR_Tools (the one in miscellaneous), and even then, it isn't that script's job to do it.
1. That's how we built it.

If there are others who don't understand (I mean us) the reason in the future, I left in here some comments for them to understand where script_tools gets installed from. 