### PR TITLE
fix - change name of the package

### DIFF
--- a/miscellaneous/setup.py
+++ b/miscellaneous/setup.py
@@ -23,7 +23,7 @@ IF CHANGES ARE NEEDED EDIT THE ONE IN RfR THEN PULL IT HERE
 '''
 import setuptools
 setuptools.setup(
-	name="Dexter AutoDetection and I2C Mutex",
+	name="Dexter_AutoDetection_and_I2C_Mutex",
 	description="Dexter Industries Robot Autodetection and I2C Mutex Security",
 	author="Dexter Industries",
 	url="http://www.dexterindustries.com/GoPiGo/",


### PR DESCRIPTION
Getting an `Invalid requirement, parse error at "'autodete'"`  error when trying to install this python package with pipenv. The problem comes from the spaces in the package's name, so replacing those with underscores does the job.