### PR TITLE
auto_detect_robot failing on standalone raspbian.  Scratch no longer installed by default

### DIFF
--- a/Scratch_GUI/install.sh
+++ b/Scratch_GUI/install.sh
@@ -54,18 +54,26 @@ sudo rm -f /usr/share/raspi-ui-overrides/applications/scratch.desktop
 sudo rm -f /usr/share/applications/scratch.desktop
 sudo lxpanelctl restart
 # Make shortcut executable
-sudo chmod +x $PIHOME/Desktop/Scratch_Start.desktop							# Desktop shortcut permissions.
 
-# sudo rm /usr/share/applications/scratch.desktop															# Remove the Scratch Start button in the Menu
+# Desktop shortcut permissions.
+sudo chmod +x $PIHOME/Desktop/Scratch_Start.desktop							
+# Remove the Scratch Start button in the Menu
+# sudo rm /usr/share/applications/scratch.desktop
 
 ######
 # Added these to solve the menu problem of scratch.  Then removed them.  
 # These are removed for now, the call up the Scratch Gui, not the scratch start.
-# sudo rm /usr/share/raspi-ui-overrides/applications/scratch.desktop					# Remove the Scratch Start button in the Menu
-# sudo cp /home/pi/$DEXTER/Scratch_GUI/Scratch_Start.desktop /usr/share/applications/scratch.desktop						# Copy the Scratch_Start to the Menu
-# sudo cp /home/pi/$DEXTER/Scratch_GUI/Scratch_Start.desktop /usr/share/raspi-ui-overrides/applications/scratch.desktop		# Copy the Scratch_Start to the Menu
-# sudo chmod 777 /usr/share/applications/scratch.desktop							# Menu Shortcut Permissions.
-# sudo chmod 777 /usr/share/raspi-ui-overrides/applications/scratch.desktop		# Menu Shortcut Permissions.
+# Desktop shortcut permissions.
+# sudo rm /usr/share/raspi-ui-overrides/applications/scratch.desktop
+# Remove the Scratch Start button in the Menu
+# Copy the Scratch_Start to the Menu
+# sudo cp /home/pi/$DEXTER/Scratch_GUI/Scratch_Start.desktop /usr/share/applications/scratch.desktop
+# Copy the Scratch_Start to the Menu
+# sudo cp /home/pi/$DEXTER/Scratch_GUI/Scratch_Start.desktop /usr/share/raspi-ui-overrides/applications/scratch.desktop	
+# Menu Shortcut Permissions.
+# sudo chmod 777 /usr/share/applications/scratch.desktop							
+# Menu Shortcut Permissions.
+# sudo chmod 777 /usr/share/raspi-ui-overrides/applications/scratch.desktop		
 
 # # Make run_scratch_gui executable.
 sudo chmod +x $FINAL_SCRATCH_PATH/Scratch_Start.sh
@@ -136,6 +144,7 @@ if [ $VERSION -eq '8' ] ; then
     echo "remoteconnectiondialog = 0" > /home/pi/.scratch.ini
 elif [ $VERSION -eq '9' ] ; then
     # associate Scratch file to our program
+    sudo apt-get install nuscratch
     cp -f $FINAL_SCRATCH_PATH/mimeapps.list $PIHOME/.config/
 fi
 

--- a/miscellaneous/auto_detect_robot.py
+++ b/miscellaneous/auto_detect_robot.py
@@ -8,13 +8,21 @@ THIS IS NOT A COPY OF ANOTHER FILE.
 
 import sys
 import time     # import the time library for the sleep function
-from smbus import SMBus
+
 import os
 import serial
 from shutil import copyfile
 import re
 
-bus = SMBus(1)
+# if GoPiGo3 installed as standalone on Raspbian
+# then smbus is not installed.
+# but there's no need to detect the robots that require it
+try:
+    from smbus import SMBus
+    bus = SMBus(1)
+except:
+    bus = None
+
 detected_robot = "None"
 detectable_robots = ["GoPiGo3","GoPiGo","BrickPi3","BrickPi+","GrovePi","PivotPi"]
 
@@ -235,9 +243,10 @@ def remove_symlink(src):
 
 def remove_desktop_control(file):
     try:
-        os.remove(file) # Delete the GoPiGo3 file.
+        os.remove(file) # Delete the file.
     except OSError as e:
-        print("File Not Found:" + file + "  " + str(e))
+        pass #quiet is better for the user. This error seems important
+        # print("File Not Found: " + file + "  " + str(e))
         # print(e)
 
 def remove_control_panel(detected_robot_list):


### PR DESCRIPTION
When installing **GoPiGo3** on standalone raspbian, the _auto_detect_robot_ tool fails because smbus is not installed.

While we could just install it and be done with it, there's really no reason to as the robots that require it have not been installed anyway. Therefore _auto_detect_robot_ should just ignore the error and be unable to detect a **GoPiPo** or a **GrovePi** as they are not installed.  Should the user decide to install those on the same SD card, then smbus will be installed and _auto_detect_robot_ will behave normally

Scratch 1.4 is now installed by the install script as we can no longer rely on its presence on the OS. Changes before line 70 are just me moving comments from the far right to the left, political comment not withstanding.