### PR TITLE
fix - gui in buster

### DIFF
--- a/Scratch_GUI/install.sh
+++ b/Scratch_GUI/install.sh
@@ -23,7 +23,7 @@ source $PIHOME/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 
 if ! quiet_mode
 then
-    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes
+    sudo apt-get install python-wxgtk3.0 python-wxtools wx3.0-i18n python-psutil --yes
 fi
 
 # ensure ~/Dexter/lib/Dexter exists

--- a/Troubleshooting_GUI/install.sh
+++ b/Troubleshooting_GUI/install.sh
@@ -39,4 +39,4 @@ sudo chmod +x /home/pi/Desktop/Troubleshooting_Start.desktop
 
 delete_folder /home/pi/GoBox/Troubleshooting
 
-feedback "Done with TRoubleshooting"
+feedback "Done with Troubleshooting"

--- a/Troubleshooting_GUI/install.sh
+++ b/Troubleshooting_GUI/install.sh
@@ -24,7 +24,7 @@ source $PIHOME/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 
 if ! quiet_mode
 then
-    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes
+    sudo apt-get install python-wxgtk3.0 python-wxtools wx3.0-i18n python-psutil --yes
 fi
 
 feedback "Installing TroubleShooting"


### PR DESCRIPTION
Attempt to fix the GUI problem in Buster. It looks like the `python-wxgtk2.8` package is no longer available in Buster and that causes all other packages to not get installed - specifically `python-wxgtk3.0` which is absolutely necessary for our GUI apps.

This is the error I was getting whenever a robot is being installed:
<img width="600" alt="Screenshot 2019-06-26 14 41 02" src="https://user-images.githubusercontent.com/26958764/60178290-cea97480-9823-11e9-9dd9-9c976d8cfdd3.png">

With this fix, the `python-wxgtk3.0` and `wx3.0-i18n` packages get installed.