### PR TITLE
Fix/buster support

### DIFF
--- a/Troubleshooting_GUI/install.sh
+++ b/Troubleshooting_GUI/install.sh
@@ -24,7 +24,7 @@ source $PIHOME/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
 
 if ! quiet_mode
 then
-    sudo apt-get install python-wxgtk2.8 python-wxgtk3.0 python-wxtools wx2.8-i18n python-psutil --yes
+    sudo apt-get install python-wxgtk3.0 python-wxtools python-psutil --yes
 fi
 
 feedback "Installing TroubleShooting"


### PR DESCRIPTION
python-wxgtk2.8 is no longer available on Buster, and thus the apt call fails